### PR TITLE
Add HA services for Becker device pairing and listing database contents

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,8 @@ import logging
 
 from homeassistant.const import MATCH_ALL
 
+from .rf_device import PyBecker
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -56,3 +58,12 @@ def extract_entities(
         entity_ids = manual_entity_ids
 
     return entity_ids
+
+
+async def async_setup(hass, config):
+    """Setup the becker component"""
+
+    # Register this component's services
+    await PyBecker.async_register_services(hass)
+
+    return True

--- a/const.py
+++ b/const.py
@@ -6,5 +6,9 @@ MANUFACTURER = "Becker"
 DEVICE_CLASS = "shutter"
 
 CONF_CHANNEL = "channel"
+CONF_UNIT = "unit"
 
-DEFAULT_CONF_USB_STICK_PATH = "/dev/serial/by-id/usb-BECKER-ANTRIEBE_GmbH_CDC_RS232_v125_Centronic-if00"
+DEFAULT_CONF_USB_STICK_PATH = (
+    "/dev/serial/by-id/usb-BECKER-ANTRIEBE_GmbH_CDC_RS232_v125_Centronic-if00"
+)
+

--- a/cover.py
+++ b/cover.py
@@ -12,7 +12,7 @@ from homeassistant.components.cover import (
     SUPPORT_OPEN,
     SUPPORT_STOP,
     SUPPORT_OPEN_TILT,
-    SUPPORT_CLOSE_TILT
+    SUPPORT_CLOSE_TILT,
 )
 from homeassistant.const import (
     CONF_FRIENDLY_NAME,
@@ -24,12 +24,7 @@ from homeassistant.const import (
     STATE_OPEN,
 )
 
-from .const import (
-    DOMAIN,
-    CONF_CHANNEL,
-    DEVICE_CLASS,
-    DEFAULT_CONF_USB_STICK_PATH
-)
+from .const import DOMAIN, CONF_CHANNEL, DEVICE_CLASS, DEFAULT_CONF_USB_STICK_PATH
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -40,7 +35,9 @@ from pybecker.becker import Becker
 
 _LOGGER = logging.getLogger(__name__)
 
-COVER_FEATURES = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT
+COVER_FEATURES = (
+    SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT
+)
 
 
 _VALID_STATES = [STATE_OPEN, STATE_CLOSED, "true", "false"]
@@ -82,16 +79,18 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         channel = device_config.get(CONF_CHANNEL)
         state_template = device_config.get(CONF_VALUE_TEMPLATE)
         if channel is None:
-            _LOGGER.error(
-                "Must specify %s", CONF_CHANNEL
-            )
+            _LOGGER.error("Must specify %s", CONF_CHANNEL)
             continue
         templates = {
             CONF_VALUE_TEMPLATE: state_template,
         }
         initialise_templates(hass, templates)
         entity_ids = extract_entities(device, "cover", None, templates)
-        covers.append(BeckerDevice(becker, friendly_name, int(channel), state_template, entity_ids))
+        covers.append(
+            BeckerDevice(
+                becker, friendly_name, int(channel), state_template, entity_ids
+            )
+        )
 
     async_add_entities(covers)
 
@@ -101,7 +100,7 @@ class BeckerDevice(CoverDevice, RestoreEntity):
     Representation of a Becker cover device.
     """
 
-    def __init__(self,  becker, name, channel, state_template, entity_ids, position=0):
+    def __init__(self, becker, name, channel, state_template, entity_ids, position=0):
         """Init the Becker device."""
         self._becker = becker
         self._name = name
@@ -179,7 +178,7 @@ class BeckerDevice(CoverDevice, RestoreEntity):
         await self._becker.stop(self._channel)
 
     async def async_update(self):
-        #await super().async_update()
+        # await super().async_update()
         if self._template is not None:
             try:
                 state = self._template.async_render().lower()
@@ -189,7 +188,11 @@ class BeckerDevice(CoverDevice, RestoreEntity):
                     else:
                         self._position = 0
                 else:
-                    _LOGGER.error("Received invalid cover is_on state: %s. Expected: %s", state, ", ".join(_VALID_STATES))
+                    _LOGGER.error(
+                        "Received invalid cover is_on state: %s. Expected: %s",
+                        state,
+                        ", ".join(_VALID_STATES),
+                    )
                     self._position = None
             except TemplateError as ex:
                 _LOGGER.error(ex)

--- a/cover.py
+++ b/cover.py
@@ -24,14 +24,13 @@ from homeassistant.const import (
     STATE_OPEN,
 )
 
-from .const import DOMAIN, CONF_CHANNEL, DEVICE_CLASS, DEFAULT_CONF_USB_STICK_PATH
+from .const import DOMAIN, CONF_CHANNEL, DEVICE_CLASS
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.exceptions import TemplateError
 from . import extract_entities, initialise_templates
-
-from pybecker.becker import Becker
+from .rf_device import PyBecker
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,13 +65,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     covers = []
 
     stick_path = config.get(CONF_DEVICE)
-    if not stick_path:
-        stick_path = DEFAULT_CONF_USB_STICK_PATH
+    PyBecker.setup(stick_path)
 
-    becker = Becker(stick_path, True)
     # To be sure the connexion is well established send 3 commands
     for x in range(0, 2):
-        becker.stop("1")
+        PyBecker.becker.stop("1")
 
     for device, device_config in config[CONF_COVERS].items():
         friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
@@ -88,7 +85,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         entity_ids = extract_entities(device, "cover", None, templates)
         covers.append(
             BeckerDevice(
-                becker, friendly_name, int(channel), state_template, entity_ids
+                PyBecker.becker, friendly_name, int(channel), state_template, entity_ids
             )
         )
 

--- a/rf_device.py
+++ b/rf_device.py
@@ -1,0 +1,24 @@
+"""Handling of the Becker USB device."""
+
+import logging
+
+from pybecker.becker import Becker
+
+from .const import DEFAULT_CONF_USB_STICK_PATH
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PyBecker:
+    """Manages a (single, global) pybecker Becker instance."""
+
+    becker = None
+
+    @classmethod
+    def setup(cls, stick_path=None):
+        """Setup becker instance."""
+
+        if not stick_path:
+            stick_path = DEFAULT_CONF_USB_STICK_PATH
+
+        cls.becker = Becker(stick_path, True)

--- a/rf_device.py
+++ b/rf_device.py
@@ -2,11 +2,20 @@
 
 import logging
 
+import voluptuous as vol
+
 from pybecker.becker import Becker
 
-from .const import DEFAULT_CONF_USB_STICK_PATH
+from .const import DOMAIN, DEFAULT_CONF_USB_STICK_PATH, CONF_CHANNEL, CONF_UNIT
 
 _LOGGER = logging.getLogger(__name__)
+
+PAIR_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CHANNEL): vol.All(int, vol.Range(min=1, max=7)),
+        vol.Optional(CONF_UNIT): vol.All(int, vol.Range(min=1, max=5)),
+    }
+)
 
 
 class PyBecker:
@@ -22,3 +31,34 @@ class PyBecker:
             stick_path = DEFAULT_CONF_USB_STICK_PATH
 
         cls.becker = Becker(stick_path, True)
+
+    @classmethod
+    async def async_register_services(cls, hass):
+        """Registers component services."""
+
+        hass.services.async_register(DOMAIN, "pair", cls.handle_pair, PAIR_SCHEMA)
+        hass.services.async_register(DOMAIN, "log_units", cls.handle_log_units)
+
+    @classmethod
+    async def handle_pair(cls, call):
+        """Service to pair with a cover receiver."""
+
+        channel = call.data.get(CONF_CHANNEL)
+        unit = call.data.get(CONF_UNIT, 1)
+        await cls.becker.pair(f"{unit}:{channel}")
+
+    @classmethod
+    async def handle_log_units(cls, call):
+        """Service that logs all paired units."""
+        units = await cls.becker.list_units()
+
+        # Apparently the SQLite results are implicitly returned in unit id
+        # order. This seems pretty dirty to rely on.
+        unit_id = 1
+        _LOGGER.info("Configured Becker centronix units:")
+        for row in units:
+            unit_code, increment = row[0:2]
+            _LOGGER.info(
+                "Unit id %d, unit code %s, increment %d", unit_id, unit_code, increment
+            )
+            unit_id += 1

--- a/services.yaml
+++ b/services.yaml
@@ -1,0 +1,13 @@
+# Becker services
+
+pair:
+  description: "Pair with a cover receiver, when master transmitter is in pairing mode"
+  fields:
+    channel:
+      description: "Channel to pair the receiver on (1-7)"
+      example: 1
+    unit:
+      description: "Sender unit to use for pairing (1-5)"
+      example: 1
+log_units:
+  description: "Log all configured/paired units"


### PR DESCRIPTION
I added a Home Assistant service "pair" that allows pairing of Becker cover devices from the UI, or automatically in automations etc.

For convenience I also added a "log_units" service that logs the contents of the pybecker database. This requires a small update to pybecker.

My dev environment automatically ran cover.py through the "black" code formatter, and since that's actually required for upstream submission, I decided to leave it that way (but as a separate commit).