### PR TITLE
Added mandatory version information

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "domain": "becker",
   "name": "Becker",
   "documentation": "",
+  "version": "0.0.1",
   "requirements": ["pybecker==1.0.5"],
   "dependencies": [],
   "codeowners": ["@nicolasberthel"]


### PR DESCRIPTION
The logs in Home Assistant says:
```
No 'version' key in the manifest file for custom integration 'becker'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'becker'
```